### PR TITLE
lsem.permutationTest: add sufficient_statistics to arglist

### DIFF
--- a/R/lsem.permutationTest.R
+++ b/R/lsem.permutationTest.R
@@ -33,6 +33,7 @@ lsem.permutationTest <- function( lsem.object, B=1000, residualize=TRUE,
     arglist$standardized <- lsem.object$standardized
     arglist$standardized_type <- lsem.object$standardized_type
     arglist$lavaan_fct <- lsem.object$lavaan_fct
+    arglist$sufficient_statistics <- lsem.object$sufficient_statistics
     use_lavaan_survey <- FALSE
     arglist$pseudo_weights <- lsem.object$pseudo_weights
 


### PR DESCRIPTION
Hello Alexander, 

I ran into a problem with the `lsem.permutationTest` function.

Here is a reproducible example:

```r
library(MASS)
library(sirt)

sigma <- matrix(.5, nrow = 4, ncol = 4)
diag(sigma) <- 1

colnames(sigma) <- rownames(sigma) <- c('V1', 'V2', 'V3', 'V4')

mu = c(1, 2, 3, 4)

df <- as.data.frame(mvrnorm(n = 1000, Sigma = sigma, mu = mu))
df$moderator <- sample(c(1,2,3), size = 1000, replace = T)

mod <- 'g =~ V1 + V2 + V3 + V4'

lsem.object <- lsem.estimate(df, 
                             moderator = 'moderator', 
                             moderator.grid = 1:3, 
                             lavmodel = mod, 
                             sufficient_statistics = FALSE, 
                             estimator = 'MLM')

lsem.permutation <- lsem.permutationTest(lsem.object, B = 3)

```
This gives the error
`Error in res0$parameters : $ operator is invalid for atomic vectors`


When looking into the source code I found that the problem arises because the  `lsem.permutationTest` function does not  consider the `sufficient_statistics` argument of the `lsem.object` when estimating LSEMs with the permuted data sets. However, because I want to use the MLM estimator, lavaan threw an error when using the default of `sufficient_statistics = TRUE`.

In the pull request, I added `sufficient_statistics` to `arglist` which fixed the error.
