### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
 LinkingTo: 
     pbv, Rcpp, RcppArmadillo
 URL: 
-    https://github.com/alexanderrobitzsch/sirt,
+    https://alexanderrobitzsch.github.io/sirt/,
     https://sites.google.com/view/alexander-robitzsch/software
+BugReports: https://github.com/alexanderrobitzsch/sirt/issues
 License: GPL (>= 2)


### PR DESCRIPTION
To improve discoverability and enable crosslinking https://blog.r-hub.io/2019/12/10/urls/

Edit: I see that the build is outdated. to automate building the site, you can use `usethis::use_pkgdown_github_actions()`, which does everything you need to deploy automatically the website on push!